### PR TITLE
ci: generate tarballs

### DIFF
--- a/.github/actions/meson/action.yml
+++ b/.github/actions/meson/action.yml
@@ -13,7 +13,7 @@ runs:
       run: pip install meson ninja
       shell: bash
     - id: setup
-      run: meson setup builddir -Db_coverage=true
+      run: meson setup builddir -Dwayland=enabled
       shell: bash
       env:
         CC: ${{ inputs.cc }}
@@ -23,10 +23,20 @@ runs:
     - id: test
       run: ninja -C builddir test
       shell: bash
-    - id: doxy
-      run: ninja -C builddir doc/html 2>&1 > doxygen.log
+    - id: dist
+      run: meson dist -C builddir --include-subprojects --formats xztar,gztar --no-tests
       shell: bash
-    - id: doxycheck
-      uses: ./.github/actions/doxycheck
+    - id: upload
+      uses: actions/upload-artifact@v2
       with:
-        logfile: doxygen.log
+        name: tarballs
+        path: |
+          builddir/meson-dist/*.tar.xz
+          builddir/meson-dist/*.tar.gz
+    # - id: doxy
+    #   run: ninja -C builddir doc/html 2>&1 > doxygen.log
+    #   shell: bash
+    # - id: doxycheck
+    #   uses: ./.github/actions/doxycheck
+    #   with:
+    #     logfile: doxygen.log

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -20,6 +20,7 @@ runs:
           lcov \
           libpango1.0-dev \
           libstartup-notification0-dev \
+          libwayland-dev \
           libxcb-ewmh-dev \
           libxcb-icccm4-dev \
           libxcb-randr0-dev \
@@ -37,14 +38,15 @@ runs:
           python3-wheel \
           texi2html \
           texinfo \
+          wayland-protocols \
           xdotool \
           xfonts-base \
           xterm \
           xutils-dev
       shell: bash
-    - id: doxy
-      run: git clone https://github.com/alobbs/doxy-coverage
-      shell: bash
+    # - id: doxy
+    #   run: git clone https://github.com/alobbs/doxy-coverage
+    #   shell: bash
     - id: check
       run: |
         curl -L https://github.com/libcheck/check/releases/download/0.14.0/check-0.14.0.tar.gz | tar xzf -

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: CI Build
 on:
   push:
     branches:
-      - next
+      - wayland
     paths-ignore:
       - "**.md"
       - "**.markdown"
@@ -35,23 +35,23 @@ jobs:
       - uses: ./.github/actions/meson
         with:
           cc: clang
-  build-autotools-gcc:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - uses: ./.github/actions/setup
-      - uses: ./.github/actions/autotools
-        with:
-          cc: gcc
-  build-autotools-clang:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - uses: ./.github/actions/setup
-      - uses: ./.github/actions/autotools
-        with:
-          cc: clang
+  # build-autotools-gcc:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         submodules: recursive
+  #     - uses: ./.github/actions/setup
+  #     - uses: ./.github/actions/autotools
+  #       with:
+  #         cc: gcc
+  # build-autotools-clang:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         submodules: recursive
+  #     - uses: ./.github/actions/setup
+  #     - uses: ./.github/actions/autotools
+  #       with:
+  #         cc: clang

--- a/meson-dist
+++ b/meson-dist
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+if test "$1" = ""; then
+    echo "Version not provided" >&2
+    exit 1
+fi
+
+if ! test -d "$2"; then
+    echo "Source directory not provided" >&2
+    exit 1
+fi
+
+# Generate tarball version
+echo "$1" > "$MESON_DIST_ROOT/.tarball-version"
+
+# Remove files
+pushd "$MESON_DIST_ROOT"
+
+find . -name .gitignore -delete
+rm -rf \
+.gitlab-ci.yml \
+.travis.yml \
+.github \
+data \
+releasenotes \
+doc/*.png \
+doc/help-output.txt \
+doc/sizing.svg \
+doc/Notes \
+doc/old-theme-convert-output.rasi \
+doc/test_xr.txt \
+doc/create_screenshot.sh \
+doc/README.md \
+doc/meson_build_manpages.sh \
+script/*.jpg

--- a/meson.build
+++ b/meson.build
@@ -1,11 +1,13 @@
 project('rofi', 'c',
     version: '1.7.0-wayland-dev',
-    meson_version: '>=0.47.0',
+    meson_version: '>=0.49.0',
     license: [ 'MIT' ],
     default_options: [
         'c_std=c99',
     ],
 )
+
+meson.add_dist_script('meson-dist', meson.project_version(), meson.source_root())
 
 c_compiler = meson.get_compiler('c')
 


### PR DESCRIPTION
So far the tarballs generated build properly (I have tested it locally).

Current issues:
- Should the release process be automated? I think releasing for next tag automatically is a decent option.
- ~If the release process is automated, how should I name the release? Also, since I am not using meson to generate the tarballs (don't think there is an equivalent to EXTRA_DIST ), I cannot use the project version name. Maybe use git tags?~
- ~I am using a manual text file to specify what files should be in the tarballs, is there a better approach?~


Personally, I think the release process shouldn't be automated since rofi project doesn't have many releases.

Most recent run: https://github.com/ram02z/rofi/actions/runs/1245970354 (1.29mb for both `tar.gz` and `tar.xz`)