### PR TITLE
[Meson] Fix invalid version in rofi.pc

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -323,7 +323,7 @@ pkg = import('pkgconfig')
 pkg.generate(
     filebase: 'rofi',
     name: 'rofi',
-    version: meson.project_version(),
+    version: meson.project_version().split('-')[0],
     description: 'Header files for rofi plugins',
     variables: [
         'pluginsdir=@0@'.format(join_paths('${libdir}', meson.project_name())),


### PR DESCRIPTION
```
rofi.pc: pkgconf version 1.7.0-wayland is invalid
```