### PR TITLE
Allow build without X11/XCB backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ Below is a list of the different modi:
 
 # Wayland support
 
-Wayland support is enabled by default in this fork, along with X11/XCB. You can build rofi _without_ XCB, if you like:
+Wayland support is enabled by default in this fork, along with X11/xcb. You can build rofi _without_ XCB, if you like:
 
 ```
-meson build -Dbackends=wayland
+meson build -Dxcb=disabled
 ```
 
 The rest of the installation process is unchanged (see [Installation](#Installation)).

--- a/README.md
+++ b/README.md
@@ -63,15 +63,15 @@ Below is a list of the different modi:
 
 # Wayland support
 
-To enable Wayland support, build the project with meson and make sure the wayland feature is enabled (it is by default).
+Wayland support is enabled by default in this fork, along with X11/XCB. You can build rofi _without_ XCB, if you like:
 
 ```
-meson build -Dwayland=enabled
+meson build -Dbackends=wayland
 ```
 
 The rest of the installation process is unchanged (see [Installation](#Installation)).
 
-**Rofi** can be invoked with the same CLI and configuration and can be forced to use X11 mode with the x11 flag:
+**Rofi** can be invoked with the same CLI and configuration and can be forced to use X11 mode with the x11 flag (unless the X11 backend was disabled in build):
 
     rofi -x11 ...
 

--- a/include/widgets/textbox.h
+++ b/include/widgets/textbox.h
@@ -35,7 +35,6 @@
 #include <pango/pango-fontmap.h>
 #include <pango/pango.h>
 #include <pango/pangocairo.h>
-#include <xkbcommon/xkbcommon.h>
 
 /**
  * @defgroup Textbox Textbox

--- a/include/widgets/widget.h
+++ b/include/widgets/widget.h
@@ -30,8 +30,6 @@
 #include "keyb.h"
 #include <cairo.h>
 #include <glib.h>
-#include <xcb/xcb.h>
-#include <xcb/xproto.h>
 /**
  * @defgroup widget widget
  *

--- a/include/xrmoptions.h
+++ b/include/xrmoptions.h
@@ -28,7 +28,6 @@
 #ifndef ROFI_XRMOPTIONS_H
 #define ROFI_XRMOPTIONS_H
 #include "theme.h"
-#include "xcb.h"
 // Big thanks to Sean Pringle for this code.
 
 /**

--- a/meson.build
+++ b/meson.build
@@ -54,31 +54,38 @@ deps = [
 ]
 
 
-libgwater = subproject('libgwater')
-# XCB stuff
-deps += [
-    libgwater.get_variable('libgwater_xcb'),
-    dependency('xcb'),
-    dependency('xcb-aux'),
-    dependency('xcb-xkb'),
-    dependency('xkbcommon-x11'),
-    dependency('xcb-ewmh'),
-    dependency('xcb-icccm'),
-    dependency('xcb-randr'),
-    dependency('xcb-cursor'),
-    dependency('xcb-xinerama'),
-    dependency('cairo-xcb'),
-    dependency('libstartup-notification-1.0'),
-]
+xcb_enabled = get_option('backends').contains('xcb')
+wayland_enabled = get_option('backends').contains('wayland')
 
-wayland_client = dependency('wayland-client', required: get_option('wayland'))
-wayland_protocols = dependency('wayland-protocols', version: '>= 1.17', required: get_option('wayland'))
-wayland_cursor = dependency('wayland-cursor', required: get_option('wayland'))
-if wayland_client.found()
-    deps += wayland_client
-    deps += wayland_protocols
-    deps += wayland_cursor
-    deps += libgwater.get_variable('libgwater_wayland')
+libgwater = subproject('libgwater')
+
+# XCB stuff
+if xcb_enabled
+    deps += [
+        libgwater.get_variable('libgwater_xcb'),
+        dependency('xcb'),
+        dependency('xcb-aux'),
+        dependency('xcb-xkb'),
+        dependency('xkbcommon-x11'),
+        dependency('xcb-ewmh'),
+        dependency('xcb-icccm'),
+        dependency('xcb-randr'),
+        dependency('xcb-cursor'),
+        dependency('xcb-xinerama'),
+        dependency('cairo-xcb'),
+        dependency('libstartup-notification-1.0'),
+    ]
+endif
+
+wayland_protocols = dependency('wayland-protocols', version: '>= 1.17', required: wayland_enabled)
+
+if wayland_enabled
+    deps += [
+        dependency('wayland-client'),
+        wayland_protocols,
+        dependency('wayland-cursor'),
+        libgwater.get_variable('libgwater_wayland'),
+    ]
 endif
 
 check = dependency('check', version: '>= 0.11.0', required: get_option('check'))
@@ -99,9 +106,11 @@ header_conf.set('GLIB_VERSION_MIN_REQUIRED', '(G_ENCODE_VERSION(@0@,@1@))'.forma
 header_conf.set('GLIB_VERSION_MAX_ALLOWED', '(G_ENCODE_VERSION(@0@,@1@))'.format(glib_min_major, glib_min_minor))
 
 header_conf.set('ENABLE_DRUN', get_option('drun'))
-header_conf.set('WINDOW_MODE', get_option('window'))
+# Window mode is not supported in the Wayland backend yet.
+header_conf.set('WINDOW_MODE', get_option('window') and xcb_enabled)
 
-header_conf.set('ENABLE_WAYLAND', wayland_client.found())
+header_conf.set('ENABLE_WAYLAND', wayland_enabled)
+header_conf.set('ENABLE_XCB', xcb_enabled)
 
 header_conf.set_quoted('MANPAGE_PATH', join_paths(get_option('prefix'), get_option('mandir')))
 header_conf.set_quoted('SYSCONFDIR', join_paths(get_option('prefix'), get_option('sysconfdir')))
@@ -176,15 +185,11 @@ rofi_sources = files(
         'source/dialogs/drun.c',
         'source/dialogs/dmenu.c',
         'source/dialogs/combi.c',
-        'source/dialogs/window.c',
         'source/dialogs/script.c',
         'source/dialogs/help-keys.c',
-        'source/xcb/display.c',
-        'source/xcb/view.c',
         'source/dialogs/filebrowser.c',
         'include/display.h',
         'include/xcb.h',
-        'include/xcb-internal.h',
         'include/rofi.h',
         'include/mode.h',
         'include/mode-private.h',
@@ -215,19 +220,28 @@ rofi_sources = files(
         'include/dialogs/dmenu.h',
         'include/dialogs/combi.h',
         'include/dialogs/script.h',
-        'include/dialogs/window.h',
         'include/dialogs/dialogs.h',
         'include/dialogs/help-keys.h',
         'include/dialogs/filebrowser.h',
         'include/dialogs/dmenuscriptshared.h',
 )
+if xcb_enabled
+    rofi_sources += files(
+        'source/dialogs/window.c',
+        'source/xcb/display.c',
+        'source/xcb/view.c',
+        'include/dialogs/window.h',
+        'include/xcb-internal.h',
+    )
+endif
+
 theme_lexer_sources = files('lexer/theme-lexer.l')
 theme_parser_sources = files('lexer/theme-parser.y')
 
 theme_lexer = flex.process(theme_lexer_sources)
 theme_parser = bison.process(theme_parser_sources)
 
-if get_option('wayland').enabled()
+if wayland_enabled
     wayland_sys_protocols_dir = wayland_protocols.get_pkgconfig_variable('pkgdatadir')
     wayland_scanner = find_program('wayland-scanner')
     protocols = files(

--- a/meson.build
+++ b/meson.build
@@ -54,8 +54,10 @@ deps = [
 ]
 
 
-xcb_enabled = get_option('backends').contains('xcb')
-wayland_enabled = get_option('backends').contains('wayland')
+xcb_enabled = get_option('xcb').enabled()
+wayland_enabled = get_option('wayland').enabled()
+assert(xcb_enabled or wayland_enabled,
+    'At least one of these options must be enabled: wayland, xcb')
 
 libgwater = subproject('libgwater')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,5 @@
 option('drun', type: 'boolean', value: true, description: 'Desktop file mode')
 option('window', type: 'boolean', value: true, description: 'Window switcher mode')
 option('check', type: 'feature', description: 'Build and run libcheck-based tests')
-option('backends', type: 'array', choices: ['wayland', 'xcb'], description: 'Build with Wayland and/or X11/XCB backend')
+option('wayland', type: 'feature', value: 'enabled', description: 'Build with wayland support')
+option('xcb', type: 'feature', value: 'enabled', description: 'Build with X11/xcb support')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,4 @@
 option('drun', type: 'boolean', value: true, description: 'Desktop file mode')
 option('window', type: 'boolean', value: true, description: 'Window switcher mode')
 option('check', type: 'feature', description: 'Build and run libcheck-based tests')
-option('wayland', type : 'feature', value : 'enabled', description: 'Build with wayland support')
+option('backends', type: 'array', choices: ['wayland', 'xcb'], description: 'Build with Wayland and/or X11/XCB backend')

--- a/source/dialogs/drun.c
+++ b/source/dialogs/drun.c
@@ -53,7 +53,6 @@
 #include "settings.h"
 #include "timings.h"
 #include "widgets/textbox.h"
-#include "xcb.h"
 
 #include "rofi-icon-fetcher.h"
 

--- a/source/display.c
+++ b/source/display.c
@@ -1,6 +1,5 @@
 #include "keyb.h"
 #include <glib.h>
-#include <xcb/xkb.h>
 
 #include "display-internal.h"
 #include "display.h"

--- a/source/helper.c
+++ b/source/helper.c
@@ -35,7 +35,6 @@
 #include "rofi.h"
 #include "settings.h"
 #include "view.h"
-#include "xcb.h"
 #include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/source/helper.c
+++ b/source/helper.c
@@ -660,6 +660,7 @@ int config_sanity_check(void) {
     found_error = 1;
   }
 
+#ifdef ENABLE_XCB
   // Check size
   {
     workarea mon;
@@ -676,6 +677,7 @@ int config_sanity_check(void) {
       found_error = TRUE;
     }
   }
+#endif
 
   if (config.menu_font) {
     PangoFontDescription *pfd =

--- a/source/rofi-icon-fetcher.c
+++ b/source/rofi-icon-fetcher.c
@@ -30,7 +30,6 @@
 
 #include "config.h"
 #include <stdlib.h>
-#include <xcb/xproto.h>
 
 #include "helper.h"
 #include "rofi-icon-fetcher.h"
@@ -39,7 +38,6 @@
 
 #include "keyb.h"
 #include "view.h"
-#include "xcb.h"
 
 #include "nkutils-enum.h"
 #include "nkutils-xdg-theme.h"

--- a/source/rofi.c
+++ b/source/rofi.c
@@ -40,11 +40,8 @@
 #include <sysexits.h>
 #include <time.h>
 #include <unistd.h>
-#include <xcb/xcb.h>
 
 #include <glib-unix.h>
-
-#include <libgwater-xcb.h>
 
 #ifdef USE_NK_GIT_VERSION
 #include "nkutils-git-version.h"

--- a/source/rofi.c
+++ b/source/rofi.c
@@ -875,22 +875,25 @@ int main(int argc, char *argv[]) {
   }
   TICK();
 
-  const struct _display_proxy *proxy;
+  const struct _display_proxy *proxy = NULL;
 #ifdef ENABLE_XCB
   proxy = xcb_proxy;
   config.backend = DISPLAY_XCB;
+#endif
 
 #ifdef ENABLE_WAYLAND
+#ifdef ENABLE_XCB
   const gchar *wl_display = g_getenv("WAYLAND_DISPLAY");
-  if (find_arg("-x11") < 0 && wl_display != NULL && strlen(wl_display) > 0)
-#endif
-#endif
-#ifdef ENABLE_WAYLAND
-  {
+  if (find_arg("-x11") < 0 && wl_display != NULL && strlen(wl_display) > 0) {
     proxy = wayland_proxy;
     config.backend = DISPLAY_WAYLAND;
   }
+#else
+  proxy = wayland_proxy;
+  config.backend = DISPLAY_WAYLAND;
 #endif
+#endif
+
   display_init(proxy);
 
   TICK_N("Select Backend");

--- a/source/rofi.c
+++ b/source/rofi.c
@@ -875,15 +875,20 @@ int main(int argc, char *argv[]) {
   }
   TICK();
 
-  const struct _display_proxy *proxy = xcb_proxy;
+  const struct _display_proxy *proxy;
+#ifdef ENABLE_XCB
+  proxy = xcb_proxy;
   config.backend = DISPLAY_XCB;
+
 #ifdef ENABLE_WAYLAND
-  if (find_arg("-x11") < 0) {
-    const gchar *d = g_getenv("WAYLAND_DISPLAY");
-    if (d != NULL && strlen(d) != 0) {
-      config.backend = DISPLAY_WAYLAND;
-      proxy = wayland_proxy;
-    }
+  const gchar *wl_display = g_getenv("WAYLAND_DISPLAY");
+  if (find_arg("-x11") < 0 && wl_display != NULL && strlen(wl_display) > 0)
+#endif
+#endif
+#ifdef ENABLE_WAYLAND
+  {
+    proxy = wayland_proxy;
+    config.backend = DISPLAY_WAYLAND;
   }
 #endif
   display_init(proxy);

--- a/source/wayland/view.c
+++ b/source/wayland/view.c
@@ -41,11 +41,7 @@
 
 #include <cairo.h>
 
-/** Indicated we understand the startup notification api is not yet stable.*/
-#define SN_API_NOT_YET_FROZEN
 #include "rofi.h"
-#include <libsn/sn.h>
-
 #include "settings.h"
 #include "timings.h"
 
@@ -54,7 +50,6 @@
 #include "helper-theme.h"
 #include "helper.h"
 #include "mode.h"
-#include "xrmoptions.h"
 
 #include "view-internal.h"
 #include "view.h"

--- a/source/widgets/scrollbar.c
+++ b/source/widgets/scrollbar.c
@@ -30,7 +30,6 @@
 #include "widgets/listview.h"
 #include "widgets/textbox.h"
 #include <glib.h>
-#include <xkbcommon/xkbcommon.h>
 
 #include "theme.h"
 

--- a/source/widgets/textbox.c
+++ b/source/widgets/textbox.c
@@ -36,7 +36,6 @@
 #include <glib.h>
 #include <math.h>
 #include <string.h>
-#include <xcb/xcb.h>
 
 #include "theme.h"
 

--- a/source/xrmoptions.c
+++ b/source/xrmoptions.c
@@ -32,16 +32,12 @@
 #include "rofi-types.h"
 #include "rofi.h"
 #include "settings.h"
-#include "xcb-internal.h"
-#include "xcb.h"
 #include <ctype.h>
 #include <glib.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <xcb/xcb.h>
-#include <xcb/xkb.h>
 
 ThemeWidget *rofi_configuration = NULL;
 

--- a/test/helper-config-cmdline-parser.c
+++ b/test/helper-config-cmdline-parser.c
@@ -31,10 +31,7 @@
 #include <stdio.h>
 #include <helper.h>
 #include <string.h>
-#include <xcb/xcb_ewmh.h>
 #include "display.h"
-#include "xcb.h"
-#include "xcb-internal.h"
 #include "rofi.h"
 #include "settings.h"
 #include "widgets/textbox.h"

--- a/test/helper-expand.c
+++ b/test/helper-expand.c
@@ -31,11 +31,8 @@
 #include <stdio.h>
 #include <helper.h>
 #include <string.h>
-#include <xcb/xcb_ewmh.h>
 #include "theme.h"
 #include "display.h"
-#include "xcb.h"
-#include "xcb-internal.h"
 #include "rofi.h"
 #include "settings.h"
 #include "widgets/textbox.h"

--- a/test/helper-pidfile.c
+++ b/test/helper-pidfile.c
@@ -31,10 +31,7 @@
 #include <stdio.h>
 #include <helper.h>
 #include <string.h>
-#include <xcb/xcb_ewmh.h>
 #include "display.h"
-#include "xcb.h"
-#include "xcb-internal.h"
 #include "rofi.h"
 #include "settings.h"
 #include "widgets/textbox.h"

--- a/test/helper-test.c
+++ b/test/helper-test.c
@@ -31,11 +31,8 @@
 #include <stdio.h>
 #include <helper.h>
 #include <string.h>
-#include <xcb/xcb_ewmh.h>
 #include "theme.h"
 #include "display.h"
-#include "xcb.h"
-#include "xcb-internal.h"
 #include "rofi.h"
 #include "settings.h"
 #include "rofi-icon-fetcher.h"

--- a/test/helper-tokenize.c
+++ b/test/helper-tokenize.c
@@ -31,11 +31,8 @@
 #include <stdio.h>
 #include <helper.h>
 #include <string.h>
-#include <xcb/xcb_ewmh.h>
 #include "display.h"
 #include "theme.h"
-#include "xcb.h"
-#include "xcb-internal.h"
 #include "rofi.h"
 #include "settings.h"
 #include "rofi-types.h"

--- a/test/mode-test.c
+++ b/test/mode-test.c
@@ -36,11 +36,9 @@
 #include <mode.h>
 #include <mode-private.h>
 #include <dialogs/help-keys.h>
-#include <xkbcommon/xkbcommon.h>
 #include "theme.h"
 #include "rofi.h"
 #include "display.h"
-#include "xcb.h"
 #include "widgets/textbox.h"
 #include <keyb.h>
 #include <helper.h>

--- a/test/textbox-test.c
+++ b/test/textbox-test.c
@@ -33,12 +33,10 @@
 #include <glib.h>
 #include <history.h>
 #include <string.h>
-#include <xcb/xcb.h>
 #include <widgets/textbox.h>
 #include <rofi.h>
-#include <cairo-xlib.h>
+#include <cairo.h>
 #include "display.h"
-#include "xcb.h"
 #include "settings.h"
 #include "xrmoptions.h"
 

--- a/test/theme-parser-test.c
+++ b/test/theme-parser-test.c
@@ -31,12 +31,9 @@
 #include <stdio.h>
 #include <helper.h>
 #include <string.h>
-#include <xcb/xcb_ewmh.h>
-#include "xcb-internal.h"
 #include "rofi.h"
 #include "settings.h"
 #include "display.h"
-#include "xcb.h"
 #include "theme.h"
 #include "css-colors.h"
 #include "widgets/widget-internal.h"

--- a/test/widget-test.c
+++ b/test/widget-test.c
@@ -37,7 +37,6 @@
 #include "rofi.h"
 #include "display.h"
 #include "xrmoptions.h"
-#include "xcb.h"
 #include "rofi-icon-fetcher.h"
 unsigned int test =0;
 #define TASSERT( a )    {                                 \


### PR DESCRIPTION
This PR replaces build option `wayland` with multi-choice option `backends` which allows to choose which backends to build:

* `xcb` (replaces `wayland=disabled`)
* `wayland` (this is the goal of this PR)
* `xcb,wayland` (replaces `wayland=enabled`)

I’ve tested it on Alpine Linux – the following diff shows the difference between tracked dynamic dependencies between rofi built with both XCB and Wayland backends (the current state) and with Wayland backend only:

```diff
--- wayland
+++ xcb,wayland
 so:libgobject-2.0.so.0
 so:libpango-1.0.so.0
 so:libpangocairo-1.0.so.0
-so:libstartup-notification-1.so.0
 so:libwayland-client.so.0
 so:libwayland-cursor.so.0
-so:libxcb-cursor.so.0
-so:libxcb-ewmh.so.2
-so:libxcb-icccm.so.4
-so:libxcb-randr.so.0
-so:libxcb-util.so.1
-so:libxcb-xinerama.so.0
-so:libxcb-xkb.so.1
-so:libxcb.so.1
-so:libxkbcommon-x11.so.0
 so:libxkbcommon.so.0
```

The difference in the rofi binary size: 350 kiB vs 408 kiB

NOTE: Alpine Linux package [rofi-wayland](https://pkgs.alpinelinux.org/packages?name=rofi-wayland&branch=edge) is built with the patches from this PR (since 1.7.0-r1).

Resolves #29.