### PR TITLE
[Wayland] Implement partial support for offset properties on window

### DIFF
--- a/include/wayland.h
+++ b/include/wayland.h
@@ -41,6 +41,8 @@ cairo_surface_t *display_buffer_pool_get_next_buffer(display_buffer_pool *pool);
 void display_surface_commit(cairo_surface_t *surface);
 
 gboolean display_get_surface_dimensions(int *width, int *height);
-void display_set_surface_dimensions(int width, int height, int loc);
+void display_set_surface_dimensions(int width, int height,
+                                    int x_margin, int y_margin,
+                                    int loc);
 
 #endif

--- a/source/wayland/display.c
+++ b/source/wayland/display.c
@@ -1270,7 +1270,9 @@ gboolean display_get_surface_dimensions(int *width, int *height) {
   return FALSE;
 }
 
-void display_set_surface_dimensions(int width, int height, int loc) {
+void display_set_surface_dimensions(
+    int width, int height, int x_margin, int y_margin, int loc) {
+
   wayland->layer_width = width;
   wayland->layer_height = height;
   zwlr_layer_surface_v1_set_size(wayland->wlr_surface, width, height);
@@ -1320,6 +1322,14 @@ void display_set_surface_dimensions(int width, int height, int loc) {
   }
 
   zwlr_layer_surface_v1_set_anchor(wayland->wlr_surface, wlr_anchor);
+
+  // NOTE: Setting margin for edges we are not anchored to has no effect, so we
+  // can safely set contradictory margins (e.g. top vs bottom) - at most one of
+  // the margins on a given axis will have effect.
+  // This also means that margin has no effect if the window is centered. :(
+  zwlr_layer_surface_v1_set_margin(wayland->wlr_surface,
+                                   y_margin, -x_margin,
+                                   -y_margin, x_margin);
 }
 
 static void wayland_display_early_cleanup(void) {}

--- a/source/wayland/view.c
+++ b/source/wayland/view.c
@@ -121,12 +121,24 @@ static int rofi_get_location(RofiViewState *state) {
                                  loc_transtable[config.location]);
 }
 
+static int rofi_get_offset_px(RofiViewState *state, RofiOrientation ori) {
+  char *property = ori == ROFI_ORIENTATION_HORIZONTAL ? "x-offset" : "y-offset";
+
+  RofiDistance offset = rofi_theme_get_distance(WIDGET(state->main_window),
+                                                property, 0);
+  return distance_get_pixel(offset, ori);
+}
+
 static void wayland_rofi_view_window_update_size(RofiViewState *state) {
   if (state == NULL) {
     return;
   }
+  int offset_x = rofi_get_offset_px(state, ROFI_ORIENTATION_HORIZONTAL);
+  int offset_y = rofi_get_offset_px(state, ROFI_ORIENTATION_VERTICAL);
+
   widget_resize(WIDGET(state->main_window), state->width, state->height);
   display_set_surface_dimensions(state->width, state->height,
+                                 offset_x, offset_y,
                                  rofi_get_location(state));
 }
 


### PR DESCRIPTION
…using [zwlr_layer_surface_v1::set_margin](https://wayland.app/protocols/wlr-layer-shell-unstable-v1#zwlr_layer_shell_v1:request:get_layer_surface:arg:surface). It's only partial because surface margin has effect only when the the window is located on edge of the screen, not in center. Also the anchor property is not implemented, the anchor point is always the edge of the window corresponding to the location property.