### PR TITLE
Make cursor more customizable

### DIFF
--- a/source/widgets/textbox.c
+++ b/source/widgets/textbox.c
@@ -475,11 +475,6 @@ static void textbox_draw(widget *wid, cairo_t *draw) {
   }
   y += top;
 
-  // TODO check if this is still needed after flatning.
-  cairo_set_operator(draw, CAIRO_OPERATOR_OVER);
-  cairo_set_source_rgb(draw, 0.0, 0.0, 0.0);
-  rofi_theme_get_color(WIDGET(tb), "text-color", draw);
-
   if (tb->show_placeholder) {
     rofi_theme_get_color(WIDGET(tb), "placeholder-color", draw);
   }
@@ -512,14 +507,12 @@ static void textbox_draw(widget *wid, cairo_t *draw) {
     break;
   }
   }
-  cairo_save(draw);
-  cairo_reset_clip(draw);
-  pango_cairo_show_layout(draw, tb->layout);
-  cairo_restore(draw);
 
   // draw the cursor
-  rofi_theme_get_color(WIDGET(tb), "text-color", draw);
+  cairo_set_source_rgb ( draw, 0.0, 0.0, 0.0 );
   if (tb->flags & TB_EDITABLE && tb->blink) {
+    rofi_theme_get_color(WIDGET(tb), "text-color", draw);
+    rofi_theme_get_color(WIDGET(tb), "cursor-color", draw);
     // We want to place the cursor based on the text shown.
     const char *text = pango_layout_get_text(tb->layout);
     // Clamp the position, should not be needed, but we are paranoid.
@@ -531,11 +524,20 @@ static void textbox_draw(widget *wid, cairo_t *draw) {
     int cursor_x = pos.x / PANGO_SCALE;
     int cursor_y = pos.y / PANGO_SCALE;
     int cursor_height = pos.height / PANGO_SCALE;
-    int cursor_width = 2;
-    cairo_rectangle(draw, x + cursor_x, y + cursor_y, cursor_width,
+    RofiDistance cursor_width = rofi_theme_get_distance(WIDGET(tb), "cursor-width", 2);
+    int cursor_pixel_width = distance_get_pixel(cursor_width, ROFI_ORIENTATION_HORIZONTAL);
+    cairo_rectangle(draw, x + cursor_x, y + cursor_y, cursor_pixel_width,
                     cursor_height);
     cairo_fill(draw);
   }
+
+  // TODO check if this is still needed after flatning.
+  cairo_set_operator(draw, CAIRO_OPERATOR_OVER);
+  rofi_theme_get_color(WIDGET(tb), "text-color", draw);
+  cairo_save(draw);
+  cairo_reset_clip(draw);
+  pango_cairo_show_layout(draw, tb->layout);
+  cairo_restore(draw);
 }
 
 // cursor handling for edit mode


### PR DESCRIPTION
This pull request aims to make cursor more customizable by adding `cursor-width` and `cursor-color` to the theme. This will allow the creation of block cursors such as this:
![block_cursor](https://user-images.githubusercontent.com/24727270/192270313-37f5680b-18bc-4378-9909-6147d1ad1283.jpg)
and also address issue #788.

From my point of view, the following things have to be done before this can be merged:
- [x] Fix all current themes by adding the `cursor-color` property
- [x] Properly format the updated code

If there is anything missing from that list, please let me know or update it directly.