### PR TITLE
Small fixes for window switcher

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -202,7 +202,7 @@ https://aur.archlinux.org/packages/rofi-lbonn-wayland-git/
 
 ### Fedora
 
-https://copr.fedorainfracloud.org/coprs/alebastr/sway-extras/
+https://packages.fedoraproject.org/pkgs/rofi-wayland/rofi-wayland/
 
 ### NixOS
 

--- a/source/modes/wayland-window.c
+++ b/source/modes/wayland-window.c
@@ -586,30 +586,21 @@ static cairo_surface_t *_get_icon(const Mode *sw, unsigned int selected_line,
     return NULL;
   }
 
-  cairo_surface_t *icon = NULL;
-  gchar *transformed = NULL;
-
   if (toplevel->cached_icon_uid > 0 && toplevel->cached_icon_size == height) {
     return rofi_icon_fetcher_get(toplevel->cached_icon_uid);
   }
 
-  /** lookup icon */
+  /**
+   * Lookup icon by lowercase app_id.
+   * There's no API to request multiple names, so we do the same as XCB window
+   * mode and search for a lowercase WM_CLASS/app_id.
+   */
+  gchar *app_id_lower = g_utf8_strdown(toplevel->app_id, -1);
   toplevel->cached_icon_size = height;
-  toplevel->cached_icon_uid = rofi_icon_fetcher_query(toplevel->app_id, height);
-  icon = rofi_icon_fetcher_get(toplevel->cached_icon_uid);
-  if (icon) {
-    return icon;
-  }
+  toplevel->cached_icon_uid = rofi_icon_fetcher_query(app_id_lower, height);
+  g_free(app_id_lower);
 
-  /** lookup icon by lowercase app_id */
-  transformed = g_utf8_strdown(toplevel->app_id, strlen(toplevel->app_id));
-  toplevel->cached_icon_uid = rofi_icon_fetcher_query(transformed, height);
-  icon = rofi_icon_fetcher_get(toplevel->cached_icon_uid);
-  g_free(transformed);
-
-  /* TODO: find desktop file by app_id and get the Icon= value */
-
-  return icon;
+  return rofi_icon_fetcher_get(toplevel->cached_icon_uid);
 }
 
 #include "mode-private.h"

--- a/source/modes/wayland-window.c
+++ b/source/modes/wayland-window.c
@@ -480,10 +480,7 @@ static void helper_eval_add_str(GString *str, const char *input, int len,
   const char *input_nn = input ? input : "";
   // Both len and max_len are in characters, not bytes.
   int spaces = 0;
-  if (len == 0) {
-    spaces = MAX(0, max_len - nc);
-    g_string_append(str, input_nn);
-  } else {
+  if (len > 0) {
     if (nc > len) {
       int bl = g_utf8_offset_to_pointer(input_nn, len) - input_nn;
       char *tmp = g_markup_escape_text(input_nn, bl);
@@ -494,6 +491,11 @@ static void helper_eval_add_str(GString *str, const char *input, int len,
       char *tmp = g_markup_escape_text(input_nn, -1);
       g_string_append(str, tmp);
       g_free(tmp);
+    }
+  } else {
+    g_string_append(str, input_nn);
+    if (len == 0) {
+      spaces = MAX(0, max_len - nc);
     }
   }
   while (spaces--) {
@@ -516,9 +518,6 @@ static gboolean helper_eval_cb(const GMatchInfo *info, GString *str,
     int l = 0;
     if (match[2] == ':') {
       l = (int)g_ascii_strtoll(&match[3], NULL, 10);
-      if (l < 0) {
-        l = 0;
-      }
     }
     /* Most of the arguments are not supported on wayland */
     switch (match[1]) {


### PR DESCRIPTION
Motivated by a need to apply https://github.com/lbonn/rofi/commit/b3c46d2d5ac11c7f9f7fb27c4bf81996985ca367 to the Wayland mode.

I skimmed through the icon fetcher code and it does not work as I assumed; it will be complicated to make it check fallback names. The first query result was ignored anyways, so it's easier to drop it and always use lowercase app_id, similar to [the X11 code](https://github.com/lbonn/rofi/blob/fd0ef6bc1514a83dd18d74436cfe103444df1b6d/source/modes/window.c#L1068).

The Fedora link update is not worth a separate PR, so I just added it here.