### PR TITLE
We actually don't want PRs to go to next, do we?

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 > Please follow these steps before submitting your PR:
 >
-> - [ ] This PR targets the `next` branch and not `master`
+> - [ ] This PR targets the `wayland` branch and not `master`
 > - [ ] If your PR is a work in progress, include [WIP] in its title
 > - [ ] Its commits' summaries are reasonably descriptive
 > - [ ] You've described what this PR addresses below


### PR DESCRIPTION
Actually, that’s a serious question: do we?

I have here this patch and I am now considering where to send it: will you ever do sync with the upstream or is this fork final and we should send patches here?

```patch
From fa7f73a7a65e967b74e64c6702e01bf399adf037 Mon Sep 17 00:00:00 2001
From: =?UTF-8?q?Mat=C4=9Bj=20Cepl?= <mcepl@cepl.eu>
Date: Sat, 20 Aug 2022 21:51:51 +0200
Subject: [PATCH 1/2] Use standard xdg-terminal instead of the proprietary
 solution.

---
 config/config.c |    6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)

--- a/config/config.c
+++ b/config/config.c
@@ -53,16 +53,16 @@ Settings config = {
     .show_icons = FALSE,
 
     /** Terminal to use. (for ssh and open in terminal) */
-    .terminal_emulator = "rofi-sensible-terminal",
+    .terminal_emulator = "xdg-terminal",
     .ssh_client = "ssh",
     /** Command when executing ssh. */
-    .ssh_command = "{terminal} -e {ssh-client} {host} [-p {port}]",
+    .ssh_command = "{terminal} {ssh-client} {host} [-p {port}]",
     /** Command when running */
     .run_command = "{cmd}",
     /** Command used to list executable commands. empty -> internal */
     .run_list_command = "",
     /** Command executed when running application in terminal */
-    .run_shell_command = "{terminal} -e {cmd}",
+    .run_shell_command = "{terminal} {cmd}",
     /** Command executed on accep-entry-custom for window modus */
     .window_command = "wmctrl -i -R {window}",
     /** No default icon theme, we search Adwaita and gnome as fallback */
```