### PR TITLE
Fix extraneous leading whitespace

### DIFF
--- a/source/modes/dmenu.c
+++ b/source/modes/dmenu.c
@@ -389,7 +389,7 @@ static gchar *dmenu_format_output_string(const DmenuModePrivateData *pd,
     unsigned int index =
         (unsigned int)g_ascii_strtoull(pd->columns[i], NULL, 10);
     if (index <= ns && index > 0) {
-      if (index == 1) {
+      if (i == 0) {
         g_string_append(str_retv, splitted[index - 1]);
       } else {
         g_string_append_c(str_retv, '\t');


### PR DESCRIPTION
Fixed https://github.com/davatorium/rofi/issues/1834
<table>
<tr>
<td>

source/modes/dmenu.c

</td>
</tr>
<tr>
<td>

 ```diff
389    unsigned int index =
390        (unsigned int)g_ascii_strtoull(pd->columns[i], NULL, 10);
391    if (index <= ns && index > 0) {
-392     if (index == 1) {
+392     if (i == 0) {
393        g_string_append(str_retv, splitted[index - 1]);
394      } else {
395        g_string_append_c(str_retv, '\t');
```

</td>
</tr>
</table>