### PR TITLE
Pass the xkb `group` (a.k.a. `layout`) to `nk_bindings`

### DIFF
--- a/source/wayland/display.c
+++ b/source/wayland/display.c
@@ -459,7 +459,7 @@ static void wayland_keyboard_modifiers(void *data, struct wl_keyboard *keyboard,
                                        uint32_t mods_locked, uint32_t group) {
   wayland_seat *self = data;
   nk_bindings_seat_update_mask(wayland->bindings_seat, NULL, mods_depressed,
-                               mods_latched, mods_locked, 0, 0, 0);
+                               mods_latched, mods_locked, 0, 0, group);
 
   RofiViewState *state = rofi_view_get_active();
   if (state != NULL) {


### PR DESCRIPTION
The `group` is used by xkb to support switching between multiple layouts, without telling `nk_bindings` about this rofi always sees key presses as if they're in the first layout.

fixes #56 