### PR TITLE
Add support for click-to-exit on wayland

### DIFF
--- a/source/wayland/display.c
+++ b/source/wayland/display.c
@@ -49,6 +49,7 @@
 
 #include "keyb.h"
 #include "view.h"
+#include "settings.h"
 
 #include "display-internal.h"
 #include "display.h"
@@ -565,6 +566,14 @@ static void wayland_pointer_send_events(wayland_seat *self) {
                                      NK_BINDINGS_BUTTON_STATE_PRESS,
                                      self->button.time);
     } else {
+      // When clicking outside the view on the overlay the coordinates are always given as 0,0
+      int click_outside =
+          self->button.button == BTN_LEFT
+          && self->button.x == 0
+          && self->button.y == 0;
+      if (config.click_to_exit == TRUE && click_outside) {
+        rofi_view_temp_click_to_exit(state, 0);
+      }
       nk_bindings_seat_handle_button(wayland->bindings_seat, NULL, button,
                                      NK_BINDINGS_BUTTON_STATE_RELEASE,
                                      self->button.time);

--- a/source/wayland/view.c
+++ b/source/wayland/view.c
@@ -449,11 +449,17 @@ static void wayland_rofi_view_pool_refresh(void) {
   wayland_rofi_view_update(state, TRUE);
 }
 
+static void wayland_rofi_view_temp_click_to_exit(RofiViewState *state, xcb_window_t target) {
+  (void) target;
+  state->quit = TRUE;
+  state->retv = MENU_CANCEL;
+}
+
 static view_proxy view_ = {
     .update = wayland_rofi_view_update,
     .maybe_update = wayland_rofi_view_maybe_update,
     .temp_configure_notify = NULL,
-    .temp_click_to_exit = NULL,
+    .temp_click_to_exit = wayland_rofi_view_temp_click_to_exit,
     .frame_callback = wayland_rofi_view_frame_callback,
     .queue_redraw = wayland_rofi_view_queue_redraw,
 


### PR DESCRIPTION
At least on Hyprland this works, having an overlay appears to capture all mouse events even outside the rendered view and reports any outside as coordinate 0,0. (This does mean clicking exactly on 0,0 would also exit, but that seems an acceptably small target to me :upside_down_face:).

fixes #22 