### PR TITLE
Re-indent Wayland sources with clang-format

### DIFF
--- a/include/wayland-internal.h
+++ b/include/wayland-internal.h
@@ -41,7 +41,8 @@ typedef struct {
   struct wl_compositor *compositor;
 
   struct wl_data_device_manager *data_device_manager;
-  struct zwp_primary_selection_device_manager_v1  *primary_selection_device_manager;
+  struct zwp_primary_selection_device_manager_v1
+      *primary_selection_device_manager;
 
   struct zwlr_layer_shell_v1 *layer_shell;
 

--- a/include/wayland.h
+++ b/include/wayland.h
@@ -41,8 +41,7 @@ cairo_surface_t *display_buffer_pool_get_next_buffer(display_buffer_pool *pool);
 void display_surface_commit(cairo_surface_t *surface);
 
 gboolean display_get_surface_dimensions(int *width, int *height);
-void display_set_surface_dimensions(int width, int height,
-                                    int x_margin, int y_margin,
-                                    int loc);
+void display_set_surface_dimensions(int width, int height, int x_margin,
+                                    int y_margin, int loc);
 
 #endif

--- a/include/xcb-dummy.h
+++ b/include/xcb-dummy.h
@@ -1,8 +1,9 @@
 #ifndef ROFI_XCB_DUMMY_H
 #define ROFI_XCB_DUMMY_H
 
-// Dummy types for xcb values shared in view interface (not used in wayland mode)
-// This header exists so that rofi can be built without xcb headers present
+// Dummy types for xcb values shared in view interface (not used in wayland
+// mode) This header exists so that rofi can be built without xcb headers
+// present
 
 typedef int xcb_configure_notify_event_t;
 typedef int xcb_window_t;

--- a/source/modes/wayland-window.c
+++ b/source/modes/wayland-window.c
@@ -549,8 +549,7 @@ static char *_generate_display_string(const WaylandWindowModePrivateData *pd,
 }
 
 static char *_get_display_value(const Mode *sw, unsigned int selected_line,
-                                int *state,
-                                G_GNUC_UNUSED GList **attr_list,
+                                int *state, G_GNUC_UNUSED GList **attr_list,
                                 int get_entry) {
   WaylandWindowModePrivateData *pd =
       (WaylandWindowModePrivateData *)mode_get_private_data(sw);

--- a/source/theme.c
+++ b/source/theme.c
@@ -1114,8 +1114,8 @@ static gboolean rofi_theme_get_image_inside(Property *p, const widget *widget,
       default:
         break;
       }
-      // FIXME: cache when hsize, wsize and scale do not change without modifying
-      // RofiImage (for ABI compatibility)
+      // FIXME: cache when hsize, wsize and scale do not change without
+      // modifying RofiImage (for ABI compatibility)
       p->value.image.surface_id =
           rofi_icon_fetcher_query_advanced(p->value.image.url, wsize, hsize);
       cairo_surface_t *img = rofi_icon_fetcher_get(p->value.image.surface_id);

--- a/source/wayland/display.c
+++ b/source/wayland/display.c
@@ -217,7 +217,7 @@ wayland_buffer_pool *display_buffer_pool_new(gint width, gint height) {
 }
 
 void display_buffer_pool_free(wayland_buffer_pool *self) {
-  if ( self == NULL ) {
+  if (self == NULL) {
     return;
   }
   self->to_free = TRUE;
@@ -322,9 +322,9 @@ static void wayland_frame_callback(void *data, struct wl_callback *callback,
     rofi_view_frame_callback();
   }
   if (wayland->surface != NULL) {
-      wayland->frame_cb = wl_surface_frame(wayland->surface);
-      wl_callback_add_listener(wayland->frame_cb,
-                               &wayland_frame_wl_callback_listener, wayland);
+    wayland->frame_cb = wl_surface_frame(wayland->surface);
+    wl_callback_add_listener(wayland->frame_cb,
+                             &wayland_frame_wl_callback_listener, wayland);
   }
 }
 
@@ -570,7 +570,8 @@ static void wayland_pointer_send_events(wayland_seat *self) {
   }
 
   if (self->motion.x > -1 || self->motion.y > -1) {
-    rofi_view_handle_mouse_motion(state, self->motion.x, self->motion.y, config.hover_select);
+    rofi_view_handle_mouse_motion(state, self->motion.x, self->motion.y,
+                                  config.hover_select);
     self->motion.x = -1;
     self->motion.y = -1;
   }
@@ -776,35 +777,39 @@ struct clipboard_read_info {
   clipboard_read_callback callback;
 };
 
-static gboolean clipboard_read_glib_callback(GIOChannel *channel, GIOCondition condition, gpointer opaque) {
+static gboolean clipboard_read_glib_callback(GIOChannel *channel,
+                                             GIOCondition condition,
+                                             gpointer opaque) {
   struct clipboard_read_info *info = opaque;
   gsize read;
 
-  switch (g_io_channel_read_chars(channel, info->buffer + info->size, CLIPBOARD_READ_INCREMENT, &read, NULL)) {
-    case G_IO_STATUS_AGAIN:
-      return TRUE;
+  switch (g_io_channel_read_chars(channel, info->buffer + info->size,
+                                  CLIPBOARD_READ_INCREMENT, &read, NULL)) {
+  case G_IO_STATUS_AGAIN:
+    return TRUE;
 
-    case G_IO_STATUS_NORMAL: {
-      info->size += read;
-      info->buffer = g_realloc(info->buffer, info->size + CLIPBOARD_READ_INCREMENT);
-      if (!info->buffer) {
-        g_io_channel_shutdown(channel, FALSE, NULL);
-        g_io_channel_unref(channel);
-        close(info->fd);
-        g_free(info);
-        return FALSE;
-      }
-      return TRUE;
-    }
-
-    default:
-      info->buffer[info->size] = '\0';
-      info->callback(info->buffer);
+  case G_IO_STATUS_NORMAL: {
+    info->size += read;
+    info->buffer =
+        g_realloc(info->buffer, info->size + CLIPBOARD_READ_INCREMENT);
+    if (!info->buffer) {
       g_io_channel_shutdown(channel, FALSE, NULL);
       g_io_channel_unref(channel);
       close(info->fd);
       g_free(info);
       return FALSE;
+    }
+    return TRUE;
+  }
+
+  default:
+    info->buffer[info->size] = '\0';
+    info->callback(info->buffer);
+    g_io_channel_shutdown(channel, FALSE, NULL);
+    g_io_channel_unref(channel);
+    close(info->fd);
+    g_free(info);
+    return FALSE;
   }
 }
 
@@ -831,7 +836,7 @@ static gboolean clipboard_read_data(int fd, clipboard_read_callback callback) {
   }
 
   g_io_add_watch(channel, G_IO_IN | G_IO_HUP | G_IO_ERR,
-      clipboard_read_glib_callback, info);
+                 clipboard_read_glib_callback, info);
 
   return TRUE;
 }
@@ -839,13 +844,12 @@ static gboolean clipboard_read_data(int fd, clipboard_read_callback callback) {
 static void data_offer_handle_offer(void *data, struct wl_data_offer *offer,
                                     const char *mime_type) {}
 
-static void data_offer_handle_source_actions(void *data,
-                       struct wl_data_offer *wl_data_offer,
-                       uint32_t source_actions) {}
+static void data_offer_handle_source_actions(
+    void *data, struct wl_data_offer *wl_data_offer, uint32_t source_actions) {}
 
 static void data_offer_handle_action(void *data,
-               struct wl_data_offer *wl_data_offer,
-               uint32_t dnd_action) {}
+                                     struct wl_data_offer *wl_data_offer,
+                                     uint32_t dnd_action) {}
 
 static const struct wl_data_offer_listener data_offer_listener = {
     .offer = data_offer_handle_offer,
@@ -1273,7 +1277,6 @@ static void wayland_layer_shell_surface_configure(
   zwlr_layer_surface_v1_ack_configure(surface, serial);
 }
 
-
 static void
 wayland_layer_shell_surface_closed(void *data,
                                    struct zwlr_layer_surface_v1 *surface) {
@@ -1294,7 +1297,7 @@ wayland_layer_shell_surface_closed(void *data,
 
   RofiViewState *state = rofi_view_get_active();
   if (state != NULL) {
-      rofi_view_set_size(state, -1, -1);
+    rofi_view_set_size(state, -1, -1);
   }
 }
 
@@ -1322,15 +1325,15 @@ static gboolean wayland_cursor_reload_theme(guint scale) {
   guint64 cursor_size = 24;
   char *env_cursor_size = (char *)g_getenv("XCURSOR_SIZE");
   if (env_cursor_size && strlen(env_cursor_size) > 0) {
-      guint64 size = g_ascii_strtoull(env_cursor_size, NULL, 10);
-      if (0 < size && size < G_MAXUINT64) {
-          cursor_size = size;
-      }
+    guint64 size = g_ascii_strtoull(env_cursor_size, NULL, 10);
+    if (0 < size && size < G_MAXUINT64) {
+      cursor_size = size;
+    }
   }
   cursor_size *= scale;
 
-  wayland->cursor.theme =
-      wl_cursor_theme_load(wayland->cursor.theme_name, cursor_size, wayland->shm);
+  wayland->cursor.theme = wl_cursor_theme_load(wayland->cursor.theme_name,
+                                               cursor_size, wayland->shm);
   if (wayland->cursor.theme != NULL) {
     const char *const *cname = (const char *const *)wayland->cursor.name;
     for (cname = (cname != NULL) ? cname : wayland_cursor_names;
@@ -1440,8 +1443,8 @@ gboolean display_get_surface_dimensions(int *width, int *height) {
   return FALSE;
 }
 
-void display_set_surface_dimensions(
-    int width, int height, int x_margin, int y_margin, int loc) {
+void display_set_surface_dimensions(int width, int height, int x_margin,
+                                    int y_margin, int loc) {
 
   wayland->layer_width = width;
   wayland->layer_height = height;
@@ -1497,8 +1500,7 @@ void display_set_surface_dimensions(
   // can safely set contradictory margins (e.g. top vs bottom) - at most one of
   // the margins on a given axis will have effect.
   // This also means that margin has no effect if the window is centered. :(
-  zwlr_layer_surface_v1_set_margin(wayland->wlr_surface,
-                                   y_margin, -x_margin,
+  zwlr_layer_surface_v1_set_margin(wayland->wlr_surface, y_margin, -x_margin,
                                    -y_margin, x_margin);
 }
 
@@ -1590,7 +1592,7 @@ static char *wayland_get_clipboard_data(int type) {
 
 static void wayland_set_fullscreen_mode() {
   if (!wayland->wlr_surface) {
-      return;
+    return;
   }
   zwlr_layer_surface_v1_set_exclusive_zone(wayland->wlr_surface, -1);
   zwlr_layer_surface_v1_set_size(wayland->wlr_surface, 0, 0);

--- a/source/wayland/view.c
+++ b/source/wayland/view.c
@@ -45,11 +45,11 @@
 #include "settings.h"
 #include "timings.h"
 
-#include "modes/modes.h"
 #include "display.h"
 #include "helper-theme.h"
 #include "helper.h"
 #include "mode.h"
+#include "modes/modes.h"
 
 #include "view-internal.h"
 #include "view.h"
@@ -96,7 +96,8 @@ static struct {
 static void wayland_rofi_view_get_current_monitor(int *width, int *height) {
   // TODO: handle changing monitor resolution
   if (WlState.monitor_width == 0 && WlState.monitor_height == 0) {
-    display_get_surface_dimensions(&WlState.monitor_width, &WlState.monitor_height);
+    display_get_surface_dimensions(&WlState.monitor_width,
+                                   &WlState.monitor_height);
   }
 
   if (width) {
@@ -129,7 +130,8 @@ static const int loc_transtable[9] = {
     WL_EAST,   WL_SOUTH | WL_EAST, WL_SOUTH, WL_SOUTH | WL_WEST,
     WL_WEST};
 
-static void wayland_rofi_view_calculate_window_position(G_GNUC_UNUSED RofiViewState *state) {}
+static void wayland_rofi_view_calculate_window_position(
+    G_GNUC_UNUSED RofiViewState *state) {}
 
 static int rofi_get_location(RofiViewState *state) {
   return rofi_theme_get_position(WIDGET(state->main_window), "location",
@@ -139,8 +141,8 @@ static int rofi_get_location(RofiViewState *state) {
 static int rofi_get_offset_px(RofiViewState *state, RofiOrientation ori) {
   char *property = ori == ROFI_ORIENTATION_HORIZONTAL ? "x-offset" : "y-offset";
 
-  RofiDistance offset = rofi_theme_get_distance(WIDGET(state->main_window),
-                                                property, 0);
+  RofiDistance offset =
+      rofi_theme_get_distance(WIDGET(state->main_window), property, 0);
   return distance_get_pixel(offset, ori);
 }
 
@@ -152,9 +154,8 @@ static void wayland_rofi_view_window_update_size(RofiViewState *state) {
   int offset_y = rofi_get_offset_px(state, ROFI_ORIENTATION_VERTICAL);
 
   widget_resize(WIDGET(state->main_window), state->width, state->height);
-  display_set_surface_dimensions(state->width, state->height,
-                                 offset_x, offset_y,
-                                 rofi_get_location(state));
+  display_set_surface_dimensions(state->width, state->height, offset_x,
+                                 offset_y, rofi_get_location(state));
   rofi_view_pool_refresh();
 }
 
@@ -189,8 +190,7 @@ static gboolean wayland_rofi_view_reload_idle(G_GNUC_UNUSED gpointer data) {
   if (state) {
     // For UI update on this.
     if (state->tb_total_rows) {
-      char *r =
-          g_strdup_printf("%u", mode_get_num_entries(state->sw));
+      char *r = g_strdup_printf("%u", mode_get_num_entries(state->sw));
       textbox_text(state->tb_total_rows, r);
       g_free(r);
     }
@@ -453,7 +453,8 @@ static void wayland_rofi_view_cleanup() {
   input_history_save();
 }
 
-static void wayland_rofi_view_set_window_title(G_GNUC_UNUSED const char *title) {}
+static void
+wayland_rofi_view_set_window_title(G_GNUC_UNUSED const char *title) {}
 
 static void wayland_rofi_view_pool_refresh(void) {
   RofiViewState *state = rofi_view_get_active();

--- a/source/xcb/view.c
+++ b/source/xcb/view.c
@@ -58,11 +58,11 @@
 #include "settings.h"
 #include "timings.h"
 
-#include "modes/modes.h"
 #include "display.h"
 #include "helper-theme.h"
 #include "helper.h"
 #include "mode.h"
+#include "modes/modes.h"
 #include "xcb-internal.h"
 #include "xrmoptions.h"
 
@@ -513,8 +513,7 @@ static gboolean xcb_rofi_view_reload_idle(G_GNUC_UNUSED gpointer data) {
   if (state) {
     // For UI update on this.
     if (state->tb_total_rows) {
-      char *r =
-          g_strdup_printf("%u", mode_get_num_entries(state->sw));
+      char *r = g_strdup_printf("%u", mode_get_num_entries(state->sw));
       textbox_text(state->tb_total_rows, r);
       g_free(r);
     }
@@ -676,7 +675,6 @@ static void open_xim_callback(xcb_xim_t *im, G_GNUC_UNUSED void *user_data) {
   free(nested.data);
 }
 #endif
-
 
 static void xcb___create_window(MenuFlags menu_flags) {
   // In password mode, disable the entry history.


### PR DESCRIPTION
No functional changes. Just makes it easier to auto-format the code for a consistent style.


> &lt;alebastr&gt; what's the clang-format config used for rofi? https://github.com/davatorium/rofi/commit/bb5868199f5dd3a42a6ce0d672d4a15887d8a7e2 implies that there is one, but it's not in the repo
> &lt;qball&gt; I used the defaults
