### PR TITLE
Cursor types and `cursor-shape-v1` support

### DIFF
--- a/include/wayland-internal.h
+++ b/include/wayland-internal.h
@@ -50,7 +50,7 @@ typedef struct {
   size_t buffer_count;
   struct {
     char *theme_name;
-    char **name;
+    RofiCursorType type;
     struct wl_cursor_theme *theme;
     struct wl_cursor *cursor;
     struct wl_cursor_image *image;
@@ -88,6 +88,7 @@ struct _wayland_seat {
     int32_t delay;
   } repeat;
   uint32_t serial;
+  uint32_t pointer_serial;
   struct wl_keyboard *keyboard;
   struct wl_pointer *pointer;
 

--- a/include/wayland-internal.h
+++ b/include/wayland-internal.h
@@ -14,6 +14,7 @@ typedef enum {
   WAYLAND_GLOBAL_COMPOSITOR,
   WAYLAND_GLOBAL_SHM,
   WAYLAND_GLOBAL_LAYER_SHELL,
+  WAYLAND_GLOBAL_CURSOR_SHAPE,
   _WAYLAND_GLOBAL_SIZE,
 } wayland_global_name;
 
@@ -39,6 +40,10 @@ typedef struct {
   struct wl_registry *registry;
   uint32_t global_names[_WAYLAND_GLOBAL_SIZE];
   struct wl_compositor *compositor;
+
+#ifdef HAVE_WAYLAND_CURSOR_SHAPE
+  struct wp_cursor_shape_manager_v1 *cursor_shape_manager;
+#endif
 
   struct wl_data_device_manager *data_device_manager;
   struct zwp_primary_selection_device_manager_v1
@@ -92,6 +97,9 @@ struct _wayland_seat {
   struct wl_keyboard *keyboard;
   struct wl_pointer *pointer;
 
+#ifdef HAVE_WAYLAND_CURSOR_SHAPE
+  struct wp_cursor_shape_device_v1 *cursor_shape_device;
+#endif
   struct wl_data_device *data_device;
   struct zwp_primary_selection_device_v1 *primary_selection_device;
 

--- a/include/wayland.h
+++ b/include/wayland.h
@@ -44,4 +44,6 @@ gboolean display_get_surface_dimensions(int *width, int *height);
 void display_set_surface_dimensions(int width, int height, int x_margin,
                                     int y_margin, int loc);
 
+void wayland_display_set_cursor_type(RofiCursorType type);
+
 #endif

--- a/meson.build
+++ b/meson.build
@@ -293,6 +293,15 @@ if wayland_enabled
         'protocols/wlr-foreign-toplevel-management-unstable-v1.xml',
         'protocols/wlr-layer-shell-unstable-v1.xml',
     )
+
+    if wayland_protocols.version().version_compare('>=1.32')
+        add_project_arguments('-DHAVE_WAYLAND_CURSOR_SHAPE', language: 'c')
+        protocols += files(
+            wayland_sys_protocols_dir + '/staging/cursor-shape/cursor-shape-v1.xml',
+            wayland_sys_protocols_dir + '/unstable/tablet/tablet-unstable-v2.xml',
+        )
+    endif
+
     proto_srcs = []
     proto_headers = []
     foreach p : protocols

--- a/source/wayland/display.c
+++ b/source/wayland/display.c
@@ -319,6 +319,7 @@ static void wayland_frame_callback(void *data, struct wl_callback *callback,
                                    uint32_t timestamp) {
   if (wayland->frame_cb != NULL) {
     wl_callback_destroy(wayland->frame_cb);
+    wayland->frame_cb = NULL;
     rofi_view_frame_callback();
   }
   if (wayland->surface != NULL) {
@@ -651,6 +652,7 @@ static void wayland_pointer_leave(void *data, struct wl_pointer *pointer,
 
   if (wayland->cursor.frame_cb != NULL) {
     wl_callback_destroy(wayland->cursor.frame_cb);
+    wayland->cursor.frame_cb = NULL;
   }
 }
 
@@ -1225,8 +1227,8 @@ static void wayland_registry_handle_global_remove(void *data,
       ((wayland->compositor == NULL) || (wayland->shm == NULL))) {
     if (wayland->cursor.frame_cb != NULL) {
       wl_callback_destroy(wayland->cursor.frame_cb);
+      wayland->cursor.frame_cb = NULL;
     }
-    wayland->cursor.frame_cb = NULL;
 
     wl_surface_destroy(wayland->cursor.surface);
     wl_cursor_theme_destroy(wayland->cursor.theme);

--- a/source/wayland/view.c
+++ b/source/wayland/view.c
@@ -176,12 +176,6 @@ static void wayland_rofi_view_get_size(RofiViewState *state, gint *width,
   *height = state->height;
 }
 
-static void wayland_rofi_view_set_cursor(RofiCursorType type) {
-  (void)type;
-
-  // TODO
-}
-
 static void wayland_rofi_view_ping_mouse(RofiViewState *state) { (void)state; }
 
 static gboolean wayland_rofi_view_reload_idle(G_GNUC_UNUSED gpointer data) {
@@ -479,7 +473,7 @@ static view_proxy view_ = {
     .calculate_window_height = wayland_rofi_view_calculate_window_height,
     .calculate_window_width = wayland_rofi_view_calculate_window_width,
     .window_update_size = wayland_rofi_view_window_update_size,
-    .set_cursor = wayland_rofi_view_set_cursor,
+    .set_cursor = wayland_display_set_cursor_type,
     .ping_mouse = wayland_rofi_view_ping_mouse,
 
     .cleanup = wayland_rofi_view_cleanup,


### PR DESCRIPTION
* Support for different cursor types.
  Testable with `rofi -theme docu ...`.
* Support for compositor-rendered cursors via [`cursor-shape-v1`](https://wayland.app/protocols/cursor-shape-v1).
  Requires wlroots >= 0.17 (Sway v1.9 or master branches) and wayland-protocols >= 1.32.
  For an extra rice, do
  ```
  seat seat1 {
    attach a-second-pointer-device
    xcursor_theme non-default-theme
  }
  ```
  and observe two cursors with different themes.

Also fixes #105

***

With that in place, I was prepared to tackle the final boss, [`fractional-scale-v1`](https://wayland.app/protocols/fractional-scale-v1)... but my holiday time off has ended.
I'll try to finish it in the next few weeks, but no promises.