### PR TITLE
[WaylandWindow] Unmap surface before sending activation request

### DIFF
--- a/source/modes/wayland-window.c
+++ b/source/modes/wayland-window.c
@@ -412,6 +412,7 @@ static ModeMode wayland_window_mode_result(Mode *sw, int mretv,
   } else if (mretv & MENU_QUICK_SWITCH) {
     retv = (ModeMode)(mretv & MENU_LOWER_MASK);
   } else if ((mretv & MENU_OK)) {
+    rofi_view_hide();
     ForeignToplevelHandle *toplevel =
         (ForeignToplevelHandle *)g_list_nth_data(pd->toplevels, selected_line);
     foreign_toplevel_handle_activate(toplevel, pd->wayland->last_seat->seat);

--- a/source/wayland/view.c
+++ b/source/wayland/view.c
@@ -423,7 +423,7 @@ static int wayland_rofi_view_calculate_window_height(RofiViewState *state) {
   return widget_get_desired_height(main_window, state->width);
 }
 
-static void wayland_rofi_view_hide(void) {}
+static void wayland_rofi_view_hide(void) { display_early_cleanup(); }
 
 static void wayland_rofi_view_cleanup() {
   g_debug("Cleanup.");


### PR DESCRIPTION
Not tested on Hyprland. Lightly tested on Sway.

Let's hope that everything that can happen after `mode_result` doesn't cause a redraw or is sufficiently protected against not having a surface. Asynchronous list updates, queued events, etc...

Fixes lbonn/rofi#117
