### PR TITLE
Update install documentation with the new rofi-wayland Arch package

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -270,7 +270,7 @@ https://pkgs.alpinelinux.org/packages?name=rofi-wayland
 
 ### ArchLinux
 
-https://aur.archlinux.org/packages/rofi-lbonn-wayland-git/
+https://archlinux.org/packages/extra/x86_64/rofi-wayland
 
 ### Fedora
 


### PR DESCRIPTION
Hi,

This rofi wayland fork is now available in the Arch Linux [[extra] repository](https://archlinux.org/packages/extra/x86_64/rofi-wayland/).
This PR aims to update the install documentation accordingly :)

Thanks for your wonderful work!