### PR TITLE
wayland/display: Fix mmap use

### DIFF
--- a/source/wayland/display.c
+++ b/source/wayland/display.c
@@ -347,7 +347,7 @@ static void wayland_keyboard_keymap(void *data, struct wl_keyboard *keyboard,
     return;
   }
 
-  char *str = mmap(NULL, size, PROT_READ, MAP_SHARED, fd, 0);
+  char *str = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
   if (str == MAP_FAILED) {
     close(fd);
     return;


### PR DESCRIPTION
> From version 7 onwards, the fd must be mapped with MAP_PRIVATE by the recipient, as MAP_SHARED may fail.

 - https://wayland.freedesktop.org/docs/html/apa.html#protocol-spec-wl_keyboard

* * *

Hi! :wave: 

I have tracked down an issue wherein on aarch64-linux, `rofi` wouldn't take any input from `niri` down to this `mmap` use.

Without this change, `rofi` stays in focus, and only using clicks or killing it does anything useful.

Any attempt to type would result in:

```
May 04 20:59:58 lumpy rofi[8874]: nk_bindings_seat_handle_key: assertion 'self->keymap != NULL' failed
```

This does not affect a system with the same configuration on `x86_64-linux`, so when reproducing YMMV.