### PR TITLE
Add foot as one of the terminals in rofi-sensible-terminal

### DIFF
--- a/doc/rofi-sensible-terminal.1.markdown
+++ b/doc/rofi-sensible-terminal.1.markdown
@@ -36,6 +36,7 @@ It tries to start one of the following (in that order):
 * alacritty
 * kitty
 * wezterm
+* foot
 
 
 ## SEE ALSO

--- a/script/rofi-sensible-terminal
+++ b/script/rofi-sensible-terminal
@@ -9,7 +9,7 @@
 # We welcome patches that add distribution-specific mechanisms to find the
 # preferred terminal emulator. On Debian, there is the x-terminal-emulator
 # symlink for example.
-for terminal in $TERMINAL x-terminal-emulator urxvt rxvt st terminology qterminal Eterm aterm uxterm xterm roxterm xfce4-terminal.wrapper mate-terminal lxterminal konsole alacritty kitty wezterm; do
+for terminal in $TERMINAL x-terminal-emulator urxvt rxvt st terminology qterminal Eterm aterm uxterm xterm roxterm xfce4-terminal.wrapper mate-terminal lxterminal konsole alacritty kitty wezterm foot; do
     if command -v $terminal >/dev/null 2>&1; then
         exec $terminal "$@"
     fi


### PR DESCRIPTION
Commonly used, a more lightweight alternative to other terminal emulators targeted at Wayland.

https://codeberg.org/dnkl/foot