### PR TITLE
Fixing incorrect link in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -140,7 +140,7 @@ The GitHub Pages version of these directions may be out of date.  Please use
 If you don't have a checkout:
 
 ```bash
-    git clone --recursive https://github.com/DaveDavenport/rofi
+    git clone --recursive https://github.com/lbonn/rofi
     cd rofi/
 ```
 


### PR DESCRIPTION
In install.md the link for a new git checkout used the link to the non-wayland version of Rofi, which would lead to a broken rofi install if someone followed the instructions on a wayland system

This pull request updates the link to the correct link for this repository
